### PR TITLE
Fix number of arguments error

### DIFF
--- a/pkg/dockerfile/parse.go
+++ b/pkg/dockerfile/parse.go
@@ -23,7 +23,7 @@ func ParseReader(r io.Reader) (*Dockerfile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dockerfile/parser.Parse %v", err)
 	}
-	stages, metaArgs, err := instructions.Parse(result.AST)
+	stages, metaArgs, err := instructions.Parse(result.AST, nil)
 	if err != nil {
 		return nil, fmt.Errorf("dockerfile/instructions.Parse %v", err)
 	}


### PR DESCRIPTION
instructions.Parse takes two arguments since
https://github.com/moby/buildkit/commit/eea0b41bf4fb1d69e109ff5ff8045c63f0c0d510#diff-ad3df5875e5e135e646046bd3c77fd5f1bb8b2d424d8e97d1ffad6c1c23a4b9a

That commit introduced second argument of type "warnCallback", currently it takes an argument of type "*linter.Linter".